### PR TITLE
`rateLimit` - Exception handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.6.1
+
+- `rateLimit` - Catch promise exceptions which will be re-thrown in `.add` or `.finish`.
+
 # 0.6.0
 
 - Added `pacemaker`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prom-utils",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prom-utils",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "ISC",
       "dependencies": {
         "debug": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prom-utils",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Promise utilities for looping: rate limiting, queueing/batching, etc.",
   "author": "GovSpend",
   "main": "dist/index.js",

--- a/src/fns.ts
+++ b/src/fns.ts
@@ -27,12 +27,14 @@ export const rateLimit = (limit: number) => {
     // Add to set
     set.add(prom)
     debug('set size: %d', set.size)
-    // Remove from set after resolving
+    // Create a new promise
     prom.then(
       () => {
         debug('delete')
+        // Remove from the set after resolving
         set.delete(prom)
       },
+      // Handle the exception so we don't throw an UnhandledPromiseRejection exception
       () => debug('exception thrown')
     )
     // Limit was reached

--- a/src/fns.ts
+++ b/src/fns.ts
@@ -17,6 +17,7 @@ const debug = _debug('prom-utils')
  * ```
  */
 export const rateLimit = (limit: number) => {
+  debug('limit: %d', limit)
   const set = new Set<Promise<any>>()
   /**
    * Add a promise. Returns immediately if limit has not been
@@ -25,10 +26,18 @@ export const rateLimit = (limit: number) => {
   const add = async (prom: Promise<any>) => {
     // Add to set
     set.add(prom)
+    debug('set size: %d', set.size)
     // Remove from set after resolving
-    prom.then(() => set.delete(prom))
+    prom.then(
+      () => {
+        debug('delete')
+        set.delete(prom)
+      },
+      () => debug('exception thrown')
+    )
     // Limit was reached
     if (set.size === limit) {
+      debug('limit reached: %d', limit)
       // Wait for one item to finish
       await Promise.race(set)
     }
@@ -36,7 +45,10 @@ export const rateLimit = (limit: number) => {
   /**
    * Wait for all promises to resolve
    */
-  const finish = () => Promise.all(set)
+  const finish = () => {
+    debug('finish')
+    return Promise.all(set)
+  }
   return { add, finish }
 }
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -41,20 +41,17 @@ describe('rateLimit', () => {
     expect(elapsed).toBeLessThan(3000)
     expect(done.length).toEqual(5)
   })
+  // This test is here to ensure that the rejected promise doesn't
+  // throw an UnhandledPromiseRejection exception.
   test('rejections should bubble up .add', async () => {
-    try {
-      const limiter = rateLimit(3)
-      await limiter.add(setTimeout(10))
-      await limiter.add(setTimeout(10))
-      // Shorter timeout to make sure that this rejects before the other promises resolve
-      await limiter.add(
-        setTimeout(5).then(() => {
-          throw 'rejectedPromise'
-        })
-      )
-    } catch (e) {
-      expect(e).toBe('rejectedPromise')
-    }
+    const limiter = rateLimit(3)
+    // Shorter timeout to make sure that this rejects before the other promises resolve
+    await limiter.add(
+      setTimeout(5).then(() => {
+        throw 'rejectedPromise'
+      })
+    )
+    await limiter.add(setTimeout(10))
   })
   test('rejections should bubble up .finish', async () => {
     try {
@@ -68,6 +65,7 @@ describe('rateLimit', () => {
       // Call finish before reaching the limit of 3
       await limiter.finish()
     } catch (e) {
+      console.log(e)
       expect(e).toBe('rejectedPromise')
     }
   })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -48,26 +48,23 @@ describe('rateLimit', () => {
     // Shorter timeout to make sure that this rejects before the other promises resolve
     await limiter.add(
       setTimeout(5).then(() => {
-        throw 'rejectedPromise'
+        throw new Error('rejectedPromise')
       })
     )
     await limiter.add(setTimeout(10))
   })
-  test('rejections should bubble up .finish', async () => {
-    try {
+  test('rejections should bubble up .finish', () => {
+    return expect(async () => {
       const limiter = rateLimit(3)
       await limiter.add(setTimeout(10))
       await limiter.add(
         setTimeout(10).then(() => {
-          throw 'rejectedPromise'
+          throw new Error('rejectedPromise')
         })
       )
       // Call finish before reaching the limit of 3
       await limiter.finish()
-    } catch (e) {
-      console.log(e)
-      expect(e).toBe('rejectedPromise')
-    }
+    }).rejects.toThrow('rejectedPromise')
   })
 })
 


### PR DESCRIPTION
**Problem**
The issue seems to be that if you pass a promise to an async function that rejects but you never await that promise or don’t explicitly catch the exception, an UnhandledPromiseRejection is thrown and Node terminates.

**Solution**
Create a new promise that handles the resolution task of removing the promise from the set but also handles the exception (swallows it). The original promise rejects but does not throw an UnhandledPromiseRejection exception since a downstream promise handles the exception. This allows for the downstream code: Promise.all or Promise.race to re-throw the rejected promise safely.