### PR TITLE
waitUntil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.8.0
+
+-   Added `waitUntil` - Wait until the predicate returns truthy or the timeout expires.
+
 # 0.7.0
 
 -   Changed dependency for determining size in bytes of a value for `batchQueue`.

--- a/README.md
+++ b/README.md
@@ -109,3 +109,16 @@ const heartbeatFn = () => {
 
 const result = await pacemaker(heartbeatFn, someProm)
 ```
+
+## waitUntil
+
+Wait until the predicate returns truthy or the timeout expires.
+Returns a promise.
+
+```typescript
+let isTruthy = false
+global.setTimeout(() => {
+    isTruthy = true
+}, 250)
+await waitUntil(() => isTruthy)
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prom-utils",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prom-utils",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "ISC",
       "dependencies": {
         "debug": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prom-utils",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Promise utilities for looping: rate limiting, queueing/batching, etc.",
   "author": "GovSpend",
   "main": "dist/index.js",
@@ -27,7 +27,8 @@
     "defer",
     "deferred",
     "pause",
-    "pausable"
+    "pausable",
+    "wait"
   ],
   "license": "ISC",
   "prettier": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,8 +5,11 @@ export type QueueResult = {
 }
 
 export interface QueueOptions {
+  /** Wait for the batch to reach this number of elements before flushing the queue. */
   batchSize?: number
+  /** Wait for the batch to reach this size in bytes before flushing the queue. */
   batchBytes?: number
+  /** Wait this long in ms before flushing the queue. */
   timeout?: number
 }
 
@@ -18,4 +21,11 @@ export type Queue = (
 export interface Deferred {
   done: () => void
   promise: Promise<void>
+}
+
+export interface WaitOptions {
+  /** Wait this long in ms before rejecting. Defaults to 5000 ms. */
+  timeout?: number
+  /** Check the predicate with this frequency. Defaults to 50 ms. */
+  checkFrequency?: number
 }


### PR DESCRIPTION
Wait until the predicate returns truthy or the timeout expires.
NOTE: This will replace https://www.npmjs.com/package/async-wait-until for simple-machines.