### PR TITLE
`pausable` - changed `proceed` to `maybeBlock`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.11.0
+
+-   `getCurrentRate` - returns an integer.
+-   `pausable` - changed `proceed` to `maybeBlock`.
+
 # 0.10.0
 
 -   Added `throughputLimiter` - Limit throughput (items/sec).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 0.11.0
 
 -   `getCurrentRate` - always returns an integer.
--   `pausable` - changed `proceed` to `maybeBlock`.
+-   BREAKING: `pausable` - changed `proceed` to `maybeBlock`.
 
 # 0.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # 0.11.0
 
--   `getCurrentRate` - always returns an integer.
--   BREAKING: `pausable` - changed `proceed` to `maybeBlock`.
+-   Fixed: `rateLimit` should remove an item if it has rejected.
+-   `rateLimit` - Added `length` getter.
+-   `batchQueue` - Added `length` getter.
+-   `throughputLimiter.getCurrentRate` - always returns an integer.
+-   BREAKING: `pausable.proceed` changed to `pausable.maybeBlock`.
 
 # 0.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.11.0
 
--   `getCurrentRate` - returns an integer.
+-   `getCurrentRate` - always returns an integer.
 -   `pausable` - changed `proceed` to `maybeBlock`.
 
 # 0.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.11.0
 
 -   Fixed: `rateLimit` should remove an item if it has rejected.
+-   `rateLimit` - `.finish` swallows exceptions.
 -   `rateLimit` - Added `length` getter.
 -   `batchQueue` - Added `length` getter.
 -   `throughputLimiter.getCurrentRate` - always returns an integer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 -   `rateLimit` - `.finish` swallows exceptions.
 -   `rateLimit` - Added `length` getter.
 -   `batchQueue` - Added `length` getter.
--   `throughputLimiter.getCurrentRate` - always returns an integer.
 -   BREAKING: `pausable.proceed` changed to `pausable.maybeBlock`.
 
 # 0.10.0

--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@ Promise utilities designed for looping.
 ## rateLimit
 
 Limit the concurrency of promises. This can be used to control
-how many requests are made to a server, for example.
+how many requests are made to a server, for example. Note:
+exceptions will be swallowed in order to prevent an UnhandledPromiseRejection
+from being thrown in the case where the promise rejects before the limit is
+reached. Therefore, you must handle exceptions on a per promise basis.
+Wrapping `rateLimit` method calls in a try/catch will not work.
 
 ```typescript
 // Limit concurrency to at most 3

--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ export interface ThroughputLimiterOptions {
 
 ## pausable
 
-Pause a loop by awaiting `proceed`. When `pause` is called `proceed` will
+Pause a loop by awaiting `maybeBlock`. When `pause` is called `maybeBlock` will
 return a promise that is resolved when `resume` is called. Otherwise,
-`proceed` will return immediately. If `timeout` is passed, `resume` will
+`maybeBlock` will return immediately. If `timeout` is passed, `resume` will
 be called after `timeout` if it is not manually called first.
 
 ```typescript
@@ -136,7 +136,7 @@ onSomeCondition(shouldProcess.pause)
 onSomeOtherCondition(shouldProcess.resume)
 
 for (const record of records) {
-    await shouldProcess.proceed()
+    await shouldProcess.maybeBlock()
     await processRecord(record)
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prom-utils",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prom-utils",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "ISC",
       "dependencies": {
         "debug": "^4.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prom-utils",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Promise utilities: rate limiting, queueing/batching, defer, etc.",
   "author": "GovSpend",
   "main": "dist/index.js",

--- a/src/fns.ts
+++ b/src/fns.ts
@@ -50,13 +50,13 @@ export const rateLimit = <T = unknown>(limit: number) => {
     // See: https://runkit.com/dubiousdavid/handling-promise-rejections
     prom.then(
       () => {
-        debugRL('delete')
+        debugRL('resolved')
         // Remove from the set
         set.delete(prom)
       },
       // Handle the exception so we don't throw an UnhandledPromiseRejection exception
       () => {
-        debugRL('exception thrown')
+        debugRL('rejected')
         // Remove from the set
         set.delete(prom)
       }

--- a/src/fns.ts
+++ b/src/fns.ts
@@ -19,7 +19,11 @@ const debugWU = _debug('prom-utils:waitUntil')
 
 /**
  * Limit the concurrency of promises. This can be used to control
- * how many requests are made to a server, for example.
+ * how many requests are made to a server, for example. Note:
+ * exceptions will be swallowed in order to prevent an UnhandledPromiseRejection
+ * from being thrown in the case where the promise rejects before the limit is
+ * reached. Therefore, you must handle exceptions on a per promise basis.
+ * Wrapping `rateLimit` method calls in a try/catch will not work.
  *
  * ```typescript
  * const limiter = rateLimit(3)
@@ -69,7 +73,7 @@ export const rateLimit = <T = unknown>(limit: number) => {
    */
   const finish = async () => {
     debugRL('finish')
-    await Promise.all(set)
+    await Promise.allSettled(set)
   }
   return {
     add,

--- a/src/fns.ts
+++ b/src/fns.ts
@@ -327,7 +327,7 @@ export const pausable = (timeout?: number) => {
   const pause = () => {
     deferred = defer()
     if (timeout) {
-      timeoutId = setTimeout(() => deferred?.done(), timeout)
+      timeoutId = setTimeout(resume, timeout)
     }
   }
   /**

--- a/src/fns.ts
+++ b/src/fns.ts
@@ -117,7 +117,7 @@ export const throughputLimiter = (
    * Get the current rate (units/sec). The rate is determined by averaging the
    * values in the sliding window where the elapsed time is determined by
    * comparing the first entry in the window to the current time. Returns 0
-   * if `throttle` has not been called. Rate is always an integer.
+   * if `throttle` has not been called.
    */
   const getCurrentRate = () => {
     debugTL('getCurrentRate called')
@@ -125,9 +125,7 @@ export const throughputLimiter = (
       const { timestamp } = slidingWindow[0]
       const numUnits = sumBy(slidingWindow, 'numUnits')
       debugTL('total units %d', numUnits)
-      const rate = Math.floor(
-        numUnits / ((new Date().getTime() - timestamp) / 1000)
-      )
+      const rate = numUnits / ((new Date().getTime() - timestamp) / 1000)
       debugTL('current rate %d', rate)
       return rate
     }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -292,7 +292,7 @@ describe('pausable', () => {
 
     const startTime = new Date().getTime()
     for (const record of records) {
-      await shouldProcess.proceed()
+      await shouldProcess.maybeBlock()
       await processRecord(record)
     }
     const endTime = new Date().getTime()
@@ -313,7 +313,7 @@ describe('pausable', () => {
 
     const startTime = new Date().getTime()
     for (const record of records) {
-      await shouldProcess.proceed()
+      await shouldProcess.maybeBlock()
       await processRecord(record)
     }
     const endTime = new Date().getTime()

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -35,7 +35,7 @@ describe('rateLimit', () => {
     expect(elapsed).toBeGreaterThan(900)
   })
   test('should finish awaiting remaining promises', async () => {
-    expect.assertions(3)
+    expect.assertions(4)
     // Pass type variable
     const limiter = rateLimit<string>(3)
     const done: string[] = []
@@ -54,11 +54,13 @@ describe('rateLimit', () => {
     const elapsed = endTime - startTime
     expect(elapsed).toBeGreaterThanOrEqual(2000)
     expect(elapsed).toBeLessThan(3000)
-    expect(done.length).toEqual(5)
+    expect(done.length).toBe(5)
+    expect(limiter.length).toBe(0)
   })
   // This test is here to ensure that the rejected promise doesn't
   // throw an UnhandledPromiseRejection exception.
   test('rejections should bubble up .add', async () => {
+    expect.assertions(1)
     const limiter = rateLimit(3)
     // Shorter timeout to make sure that this rejects before the other promises resolve
     await limiter.add(
@@ -67,6 +69,8 @@ describe('rateLimit', () => {
       })
     )
     await limiter.add(setTimeout(10))
+    await setTimeout(20)
+    expect(limiter.length).toBe(0)
   })
   test('rejections should bubble up .finish', () => {
     expect.assertions(1)
@@ -86,7 +90,7 @@ describe('rateLimit', () => {
 
 describe('batchQueue', () => {
   test('should batch items up to batchSize', async () => {
-    expect.assertions(2)
+    expect.assertions(3)
     const calls: any[] = []
     const fn = async (records: string[]) => {
       calls.push(records)
@@ -103,6 +107,7 @@ describe('batchQueue', () => {
     await queue.flush()
     expect(calls).toEqual([['Joe', 'Frank'], ['Bob']])
     expect(queue.lastResult).toBe(1)
+    expect(queue.length).toBe(0)
   })
   test('should flush queue if timeout is reached before batchSize', async () => {
     expect.assertions(1)
@@ -320,6 +325,14 @@ describe('pausable', () => {
     const elapsed = endTime - startTime
     expect(elapsed).toBeGreaterThanOrEqual(200)
     expect(records).toEqual(['Joe', 'Frank', 'Bob'])
+  })
+  test('isPaused works', () => {
+    const shouldProcess = pausable()
+    expect(shouldProcess.isPaused).toBe(false)
+    shouldProcess.pause()
+    expect(shouldProcess.isPaused).toBe(true)
+    shouldProcess.resume()
+    expect(shouldProcess.isPaused).toBe(false)
   })
 })
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -59,7 +59,7 @@ describe('rateLimit', () => {
   })
   // This test is here to ensure that the rejected promise doesn't
   // throw an UnhandledPromiseRejection exception.
-  test('rejections should bubble up .add', async () => {
+  test('rejections should not bubble up .add', async () => {
     expect.assertions(1)
     const limiter = rateLimit(3)
     // Shorter timeout to make sure that this rejects before the other promises resolve
@@ -70,9 +70,10 @@ describe('rateLimit', () => {
     )
     await limiter.add(setTimeout(10))
     await setTimeout(20)
+    // Check that the rejected promise was removed from the set.
     expect(limiter.length).toBe(0)
   })
-  test('rejections should bubble up .finish', () => {
+  test('rejections should not bubble up .finish', () => {
     expect.assertions(1)
     return expect(async () => {
       const limiter = rateLimit(3)
@@ -84,7 +85,7 @@ describe('rateLimit', () => {
       )
       // Call finish before reaching the limit of 3
       await limiter.finish()
-    }).rejects.toThrow('rejectedPromise')
+    }).not.toThrow('rejectedPromise')
   })
 })
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -75,7 +75,7 @@ describe('rateLimit', () => {
   })
   test('rejections should not bubble up .finish', () => {
     expect.assertions(1)
-    return expect(async () => {
+    expect(async () => {
       const limiter = rateLimit(3)
       await limiter.add(setTimeout(10))
       await limiter.add(

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,8 @@ export type QueueResult<A, B> = {
   lastResult?: Awaited<B>
   /** Get the current throughput rates. */
   getStats(): QueueStats
+  /** Length of the queue. */
+  get length(): number
 }
 
 export interface QueueOptions {


### PR DESCRIPTION
-   Fixed: `rateLimit` should remove an item if it has rejected.
-   `rateLimit` - `.finish` swallows exceptions.
-   `rateLimit` - Added `length` getter.
-   `batchQueue` - Added `length` getter.
-   BREAKING: `pausable.proceed` changed to `pausable.maybeBlock`.