### PR TITLE
`rateLimit` - support multiple throughput limiters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 0.20.0
 
-- `rateLimit` accepts multiple `RateLimiter` objects. Interfaces have changed slightly but existing code will work. The `getStats` method now returns an array of stats objects.
+- `rateLimit` accepts multiple `RateLimiter` objects.
+   - A new `RateLimiter` interface has been created in place of `RateLimitOptions`.
+   - The `getStats` method now returns an array of stats objects.
 
 # 0.19.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 0.20.0
 
 - `rateLimit` accepts multiple `RateLimiter` objects.
-   - A new `RateLimiter` interface has been created in place of `RateLimitOptions`.
+   - A new `RateLimiter` interface has been created in place of `RateLimitOptions`. The `maxItemsPerPeriod` field is now required.
    - The `getStats` method now returns an array of stats objects.
 
 # 0.19.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.20.0
+
+- `rateLimit` accepts multiple `RateLimiter` objects. Interfaces have changed slightly. The `getStats` method now returns an array of stats objects.
+
 # 0.19.0
 
 - BREAKING: `waitUntil` now returns the truthy value from the predicate instead of `void`. The function resolves with the result of the predicate when it becomes truthy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 0.20.0
 
-- `rateLimit` accepts multiple `RateLimiter` objects. Interfaces have changed slightly. The `getStats` method now returns an array of stats objects.
+- `rateLimit` accepts multiple `RateLimiter` objects. Interfaces have changed slightly but existing code will work. The `getStats` method now returns an array of stats objects.
 
 # 0.19.0
 

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ Limits the concurrency of promises. This can be used to control how many request
 #### Parameters
 
 - `concurrency: number` - Maximum number of concurrent promises (set to `Infinity` to disable)
-- `...rateLimiters: RateLimiter[]` - One or more rate limiter configurations (optional)
+- `...rateLimiters: RateLimiter[]` - One or more rate limiters (optional)
 
-#### Rate Limiter Configuration
+#### Rate Limiter
 
-Each rate limiter configuration is an object that extends `ThroughputLimiterOptions`:
+Each rate limiter is an object that extends `ThroughputLimiterOptions`:
 
 ```typescript
 interface RateLimiter extends ThroughputLimiterOptions {

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ Each rate limiter is an object that extends `ThroughputLimiterOptions`:
 ```typescript
 interface RateLimiter extends ThroughputLimiterOptions {
     /**
-     * Maximum throughput allowed (items/period). Defaults to items/sec.
+     * Maximum throughput allowed (items/period)
      */
-    maxItemsPerPeriod?: number
+    maxItemsPerPeriod: number
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prom-utils",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prom-utils",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "ISC",
       "dependencies": {
         "debug": "^4.4.3",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:watch": "tsc --watch",
     "test": "vitest run",
     "test:ui": "vitest --ui",
-    "test:debug": "DEBUG=prom-utils:* vitest run --disable-console-intercept --reporter=basic",
+    "test:debug": "DEBUG=prom-utils:* vitest run --disable-console-intercept",
     "test:watch": "vitest",
     "lint": "eslint src/**"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prom-utils",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Promise utilities: rate limiting, queueing/batching, defer, etc.",
   "author": "GovSpend",
   "main": "dist/index.js",

--- a/src/fns.ts
+++ b/src/fns.ts
@@ -68,9 +68,9 @@ export const rateLimit = <T = unknown>(
   // Create throughput limiters for each rate limiter configuration
   const throughputLimiters = limiters.map((options) => {
     const { maxItemsPerPeriod, period = 1000 } = options
-    debugRL('throughputLimiter: %o', { maxItemsPerPeriod, period })
+    debugRL('limiter: %o', { maxItemsPerPeriod, period })
 
-    return throughputLimiter(maxItemsPerPeriod ?? Infinity, {
+    return throughputLimiter(maxItemsPerPeriod, {
       // Allow for high throughput at the start of the period
       getTimeframe: getTimeframeUsingPeriod,
       // Expire items after the period

--- a/src/fns.ts
+++ b/src/fns.ts
@@ -41,8 +41,8 @@ export const TimeoutError = makeError('TimeoutError')
  * Wrapping `rateLimit` method calls in a try/catch will not work. You can
  * set `limit` to Infinity to disregard the limit.
  *
- * To limit the promises for a given period of time, pass one or more rate limiter
- * configurations. Each rate limiter can specify `maxItemsPerPeriod` and other
+ * To limit the promises for a given period of time, pass one or more rate limiters.
+ * Each rate limiter can specify `maxItemsPerPeriod` and other
  * throughput options. For example, the following limits the number of concurrent
  * requests to 5 and ensures that the rate never exceeds 75 requests per minute.
  *
@@ -120,7 +120,7 @@ export const rateLimit = <T = unknown>(
       )
     }
 
-    // Limit was reached
+    // Max concurrency was reached
     if (set.size === concurrency) {
       debugRL('limit reached: %d', concurrency)
       // Wait for one item to finish

--- a/src/fns.ts
+++ b/src/fns.ts
@@ -61,7 +61,7 @@ export const rateLimit = <T = unknown>(
   concurrency: number,
   ...limiters: RateLimiter[]
 ) => {
-  debugRL('init %O', { concurrency, limiters })
+  debugRL('concurrency: %d', concurrency)
   // Set of promises
   const set = new Set<Promise<T>>()
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,13 +53,12 @@ export type QueueResultParallel<A, B> = {
  * - `getTimeframe`: `getTimeframeUsingPeriod` (allows high throughput at start of period)
  * - `expireAfter`: Same as `period`
  * - `maxWindowLength`: Same as `maxItemsPerPeriod`
- * - `maxItemsPerPeriod`: Infinity (no limit)
  */
 export interface RateLimiter extends ThroughputLimiterOptions {
   /**
-   * Maximum throughput allowed (items/period). Defaults to items/sec.
+   * Maximum throughput allowed (items/period)
    */
-  maxItemsPerPeriod?: number
+  maxItemsPerPeriod: number
 }
 
 export interface AddOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,7 +42,20 @@ export type QueueResultParallel<A, B> = {
   get length(): number
 }
 
-export interface RateLimitOptions {
+/**
+ * A simplified abstraction of a throughput limiter.
+ *
+ * Extends {@link ThroughputLimiterOptions}
+ *
+ * @remarks
+ * The following defaults are applied when passed to `rateLimit`:
+ * - `period`: 1000 ms (1 second)
+ * - `getTimeframe`: `getTimeframeUsingPeriod` (allows high throughput at start of period)
+ * - `expireAfter`: Same as `period`
+ * - `maxWindowLength`: Same as `maxItemsPerPeriod`
+ * - `maxItemsPerPeriod`: Infinity (no limit)
+ */
+export interface RateLimiter extends ThroughputLimiterOptions {
   /**
    * Maximum throughput allowed (items/period). Defaults to items/sec.
    */
@@ -129,5 +142,8 @@ export interface ThroughputLimiterOptions {
 
 export type AsyncIter<T> = AsyncIterator<T> | AsyncIterable<T>
 
-export type IteratorSuccess<T> = { res: IteratorResult<T>; iterator: AsyncIterator<T> }
+export type IteratorSuccess<T> = {
+  res: IteratorResult<T>
+  iterator: AsyncIterator<T>
+}
 export type IteratorFailure<T> = { err: unknown; iterator: AsyncIterator<T> }


### PR DESCRIPTION
**Problem**

Sometimes you need multiple rate limiters (e.g., one for items/second and one for items/minute). This change supports multiple limiters while maintaining backwards compatibility with existing code.

**Changes**

- `rateLimit` accepts multiple `RateLimiter` objects.
   - A new `RateLimiter` interface has been created in place of `RateLimitOptions`. The `maxItemsPerPeriod` field is now **required** since defaulting to `Infinity` made this a no-op.
   - The `getStats` method now returns an array of stats objects.